### PR TITLE
fix can't get correct article content if search conditions are set.

### DIFF
--- a/src/sites/ptt/bot.js
+++ b/src/sites/ptt/bot.js
@@ -301,6 +301,10 @@ class Bot extends EventEmitter {
 
   async getArticle(boardname, sn) {
     await this.enterBoard(boardname);
+    if (this.isSearchConditionSet()){
+      let searchString = this.searchCondition.conditions.map(condition => condition.toSearchString()).join(key.Enter);
+      await this.send(`${searchString}${key.Enter}`);
+    }
     const { getLine } = this;
 
     await this.send(`${sn}${key.Enter}${key.Enter}`);


### PR DESCRIPTION
Dear kevinptt0323,
發現了一則遺漏的問題並修正，再麻煩你review~
Thanks

## Issue
* 如果設定了搜尋條件，會無法依照給定的`sn`取得對應的文章內容